### PR TITLE
feat: ensure theres always a valid solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 go.work
 
 build/
+main

--- a/breachModel/breachModel.go
+++ b/breachModel/breachModel.go
@@ -1,6 +1,7 @@
 package breachModel
 
 import (
+	"fmt"
 	"math/rand"
 	"time"
 )
@@ -91,6 +92,9 @@ func GenerateBreachSingleSequenceFromSurface(size int, surface [][]*BreachHole, 
 		// Update the position and direction for next iteration
 		positionX = nextHole.PositionX
 		positionY = nextHole.PositionY
+
+		fmt.Println("\033[%dX", positionX, "\033[%dY", positionY)
+
 		isRow = !isRow
 	}
 

--- a/breachModel/breachModel.go
+++ b/breachModel/breachModel.go
@@ -37,7 +37,7 @@ type BreachHoleWithPosition struct {
 	PositionY int
 }
 
-type BreachSquenceWithNextPosition struct {
+type BreachSequenceWithNextPosition struct {
 	sequence  []string
 	positionX int
 	positionY int
@@ -46,7 +46,7 @@ type BreachSquenceWithNextPosition struct {
 
 // Generates an array of random breach hole addresses with a length based on a known breach surface
 // starting from a specific position (positionX, positionY) and in a specific direction (isRow)
-func GenerateBreachSingleSequenceFromSurface(length int, surface [][]*BreachHole, positionX int, positionY int, isRow bool) BreachSquenceWithNextPosition {
+func GenerateBreachSingleSequenceFromSurface(length int, surface [][]*BreachHole, positionX int, positionY int, isRow bool) BreachSequenceWithNextPosition {
 	rand.Seed(time.Now().UnixNano())
 
 	var breachSequence = make([]string, 0)
@@ -79,7 +79,7 @@ func GenerateBreachSingleSequenceFromSurface(length int, surface [][]*BreachHole
 		isRow = !isRow
 	}
 
-	return BreachSquenceWithNextPosition{
+	return BreachSequenceWithNextPosition{
 		sequence:  breachSequence,
 		positionX: positionX,
 		positionY: positionY,

--- a/breachModel/breachModel.go
+++ b/breachModel/breachModel.go
@@ -93,7 +93,7 @@ func GenerateBreachSingleSequenceFromSurface(size int, surface [][]*BreachHole, 
 		positionX = nextHole.PositionX
 		positionY = nextHole.PositionY
 
-		fmt.Println("\033[%dX", positionX, "\033[%dY", positionY)
+		fmt.Println("\033[%dX", positionX, "\033[%dY", positionY, "\033[%dValue", nextHole.hole.Address)
 
 		isRow = !isRow
 	}

--- a/breachModel/breachModel.go
+++ b/breachModel/breachModel.go
@@ -123,7 +123,7 @@ func GenerateBreachSequencesFromSurface(size int, surface [][]*BreachHole, count
 	var isRow = true
 	var positionX = 0
 	var positionY = 0
-	var sequenceSize = size/count + 1
+	var sequenceSize = size / count
 	for i := 0; i < count; i++ {
 		var resultingSequence = GenerateBreachSingleSequenceFromSurface(sequenceSize, shallowCopyOfSurface, positionX, positionY, isRow)
 

--- a/breachModel/breachModel.go
+++ b/breachModel/breachModel.go
@@ -74,7 +74,6 @@ func GenerateBreachSingleSequenceFromSurface(size int, surface [][]*BreachHole, 
 				if hole.IsFree {
 					rowOfAvailableHoles = append(rowOfAvailableHoles, BreachHoleWithPosition{hole: hole, PositionX: positionX, PositionY: j})
 				}
-
 			}
 		} else {
 			for j := 0; j < len(surface); j++ {
@@ -120,7 +119,7 @@ func GenerateBreachSequencesFromSurface(size int, surface [][]*BreachHole, count
 	var isRow = true
 	var positionX = 0
 	var positionY = 0
-	var sequenceSize = size / count
+	var sequenceSize = size/count + 1
 	for i := 0; i < count; i++ {
 		var resultingSequence = GenerateBreachSingleSequenceFromSurface(sequenceSize, shallowCopyOfSurface, positionX, positionY, isRow)
 

--- a/breachModel/breachModel.go
+++ b/breachModel/breachModel.go
@@ -1,7 +1,6 @@
 package breachModel
 
 import (
-	"fmt"
 	"math/rand"
 	"time"
 )
@@ -71,16 +70,16 @@ func GenerateBreachSingleSequenceFromSurface(size int, surface [][]*BreachHole, 
 
 		if isRow {
 			for j := 0; j < len(surface); j++ {
-				var hole = surface[positionX][j]
+				var hole = surface[positionY][j]
 				if hole.IsFree {
-					rowOfAvailableHoles = append(rowOfAvailableHoles, BreachHoleWithPosition{hole: hole, PositionX: positionX, PositionY: j})
+					rowOfAvailableHoles = append(rowOfAvailableHoles, BreachHoleWithPosition{hole: hole, PositionX: j, PositionY: positionY})
 				}
 			}
 		} else {
 			for j := 0; j < len(surface); j++ {
-				var hole = surface[j][positionY]
+				var hole = surface[j][positionX]
 				if hole.IsFree {
-					rowOfAvailableHoles = append(rowOfAvailableHoles, BreachHoleWithPosition{hole: hole, PositionX: j, PositionY: positionY})
+					rowOfAvailableHoles = append(rowOfAvailableHoles, BreachHoleWithPosition{hole: hole, PositionX: positionX, PositionY: j})
 				}
 			}
 		}
@@ -92,9 +91,6 @@ func GenerateBreachSingleSequenceFromSurface(size int, surface [][]*BreachHole, 
 		// Update the position and direction for next iteration
 		positionX = nextHole.PositionX
 		positionY = nextHole.PositionY
-
-		fmt.Println("\033[%dX", positionX, "\033[%dY", positionY, "\033[%dValue", nextHole.hole.Address)
-
 		isRow = !isRow
 	}
 

--- a/breachModel/breachModel.go
+++ b/breachModel/breachModel.go
@@ -16,21 +16,6 @@ type BreachHole struct {
 	IsFree  bool
 }
 
-// Generates an array of random breach hole addresses with a length [2, maxLength]
-func GenerateBreachSequence(maxLength int) []string {
-	rand.Seed(time.Now().UnixNano())
-	var size = 0
-	for size < 2 {
-		size = rand.Intn(maxLength + 1)
-	}
-	var breachSequence = make([]string, size)
-	for i := 0; i < size; i++ {
-		randItemIndex := rand.Intn(len(knownBreachHoleAddresses))
-		breachSequence[i] = knownBreachHoleAddresses[randItemIndex]
-	}
-	return breachSequence
-}
-
 // Generates a square
 func GenerateBreachSurface(size int) [][]*BreachHole {
 	rand.Seed(time.Now().UnixNano())
@@ -59,13 +44,13 @@ type BreachSquenceWithNextPosition struct {
 	isRow     bool
 }
 
-// Generates an array of random breach hole addresses with a length size based on a known breach surface
+// Generates an array of random breach hole addresses with a length based on a known breach surface
 // starting from a specific position (positionX, positionY) and in a specific direction (isRow)
-func GenerateBreachSingleSequenceFromSurface(size int, surface [][]*BreachHole, positionX int, positionY int, isRow bool) BreachSquenceWithNextPosition {
+func GenerateBreachSingleSequenceFromSurface(length int, surface [][]*BreachHole, positionX int, positionY int, isRow bool) BreachSquenceWithNextPosition {
 	rand.Seed(time.Now().UnixNano())
 
 	var breachSequence = make([]string, 0)
-	for i := 0; i < size; i++ {
+	for i := 0; i < length; i++ {
 		var rowOfAvailableHoles = make([]BreachHoleWithPosition, 0)
 
 		if isRow {
@@ -102,7 +87,10 @@ func GenerateBreachSingleSequenceFromSurface(size int, surface [][]*BreachHole, 
 	}
 }
 
-func GenerateBreachSequencesFromSurface(size int, surface [][]*BreachHole, count int) [][]string {
+// Generates a list of sequences with a combined total length based on a known breach surface
+// Will randomly add overlap or remove parts of the sequences to make them more interesting
+// Shuffles the sequences at the end to not indicate the order of the sequences
+func GenerateBreachSequencesFromSurface(length int, surface [][]*BreachHole, count int) [][]string {
 
 	var shallowCopyOfSurface = make([][]*BreachHole, len(surface))
 	for i := range surface {
@@ -119,7 +107,7 @@ func GenerateBreachSequencesFromSurface(size int, surface [][]*BreachHole, count
 	var isRow = true
 	var positionX = 0
 	var positionY = 0
-	var sequenceSize = size / count
+	var sequenceSize = length / count
 	for i := 0; i < count; i++ {
 		var resultingSequence = GenerateBreachSingleSequenceFromSurface(sequenceSize, shallowCopyOfSurface, positionX, positionY, isRow)
 

--- a/breachModel/breachModel.go
+++ b/breachModel/breachModel.go
@@ -105,7 +105,15 @@ func GenerateBreachSingleSequenceFromSurface(size int, surface [][]*BreachHole, 
 
 func GenerateBreachSequencesFromSurface(size int, surface [][]*BreachHole, count int) [][]string {
 
-	// TODO clean up isFree on all entries or create copy in beginning
+	var shallowCopyOfSurface = make([][]*BreachHole, len(surface))
+	for i := range surface {
+		shallowCopyOfSurface[i] = make([]*BreachHole, len(surface[i]))
+
+		for j := range surface[i] {
+			shallowCopyOfSurface[i][j] = &BreachHole{Address: surface[i][j].Address, IsFree: true}
+		}
+
+	}
 
 	// Generate sequences based on surface
 	var sequences = make([][]string, count)
@@ -114,8 +122,7 @@ func GenerateBreachSequencesFromSurface(size int, surface [][]*BreachHole, count
 	var positionY = 0
 	var sequenceSize = size / count
 	for i := 0; i < count; i++ {
-		// TODO calculate individual size based on total size with potential overlap
-		var resultingSequence = GenerateBreachSingleSequenceFromSurface(sequenceSize, surface, positionX, positionY, isRow)
+		var resultingSequence = GenerateBreachSingleSequenceFromSurface(sequenceSize, shallowCopyOfSurface, positionX, positionY, isRow)
 
 		sequences[i] = resultingSequence.sequence
 		positionX = resultingSequence.positionX

--- a/breachModel/breachModel.go
+++ b/breachModel/breachModel.go
@@ -136,18 +136,18 @@ func GenerateBreachSequencesFromSurface(size int, surface [][]*BreachHole, count
 		action := rand.Intn(3)
 		switch action {
 		case 0:
+			// Keep it as it was
+		case 1:
 			// Add the first entry of the next sequence to the end of the current sequence
 			var nextSequence = sequences[i+1]
 			if len(nextSequence) > 0 {
 				sequences[i] = append(sequences[i], nextSequence[0])
 			}
-		case 1:
+		case 2:
 			// Remove the last entry of the current sequence
 			if len(sequences[i]) > 0 {
 				sequences[i] = sequences[i][:len(sequences[i])-1]
 			}
-		case 2:
-			// Keep it as it was
 		}
 	}
 	return sequences

--- a/breachModel/breachModel.go
+++ b/breachModel/breachModel.go
@@ -64,7 +64,7 @@ type BreachSquenceWithNextPosition struct {
 func GenerateBreachSingleSequenceFromSurface(size int, surface [][]*BreachHole, positionX int, positionY int, isRow bool) BreachSquenceWithNextPosition {
 	rand.Seed(time.Now().UnixNano())
 
-	var breachSequence = make([]string, size)
+	var breachSequence = make([]string, 0)
 	for i := 0; i < size; i++ {
 		var rowOfAvailableHoles = make([]BreachHoleWithPosition, 0)
 
@@ -86,7 +86,7 @@ func GenerateBreachSingleSequenceFromSurface(size int, surface [][]*BreachHole, 
 		}
 
 		var nextHole = rowOfAvailableHoles[rand.Intn(len(rowOfAvailableHoles))]
-		breachSequence[i] = nextHole.hole.Address
+		breachSequence = append(breachSequence, nextHole.hole.Address)
 		// Ensure we don't use the same hole twice
 		nextHole.hole.IsFree = false
 		// Update the position and direction for next iteration
@@ -116,7 +116,7 @@ func GenerateBreachSequencesFromSurface(size int, surface [][]*BreachHole, count
 	}
 
 	// Generate sequences based on surface
-	var sequences = make([][]string, count)
+	var sequences = make([][]string, 0)
 	var isRow = true
 	var positionX = 0
 	var positionY = 0
@@ -124,7 +124,7 @@ func GenerateBreachSequencesFromSurface(size int, surface [][]*BreachHole, count
 	for i := 0; i < count; i++ {
 		var resultingSequence = GenerateBreachSingleSequenceFromSurface(sequenceSize, shallowCopyOfSurface, positionX, positionY, isRow)
 
-		sequences[i] = resultingSequence.sequence
+		sequences = append(sequences, resultingSequence.sequence)
 		positionX = resultingSequence.positionX
 		positionY = resultingSequence.positionY
 		isRow = resultingSequence.isRow

--- a/breachModel/breachModel.go
+++ b/breachModel/breachModel.go
@@ -149,6 +149,8 @@ func GenerateBreachSequencesFromSurface(size int, surface [][]*BreachHole, count
 			}
 		}
 	}
+	rand.Shuffle(len(sequences), func(i, j int) { sequences[i], sequences[j] = sequences[j], sequences[i] })
+
 	return sequences
 }
 

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func getInput() byte {
 func main() {
 	var breachSurfaceSize = 6
 	var breachSurface = breachModel.GenerateBreachSurface(breachSurfaceSize)
-	var breachSequences = breachModel.GenerateBreachSequencesFromSurface(3, breachSurface, 3)
+	var breachSequences = breachModel.GenerateBreachSequencesFromSurface(6, breachSurface, 3)
 	var breachSequence1 = breachSequences[0]
 	var breachSequence2 = breachSequences[1]
 	var breachSequence3 = breachSequences[2]

--- a/main.go
+++ b/main.go
@@ -59,9 +59,10 @@ func getInput() byte {
 func main() {
 	var breachSurfaceSize = 6
 	var breachSurface = breachModel.GenerateBreachSurface(breachSurfaceSize)
-	var breachSequence1 = breachModel.GenerateBreachSequence(3)
-	var breachSequence2 = breachModel.GenerateBreachSequence(3)
-	var breachSequence3 = breachModel.GenerateBreachSequence(3)
+	var breachSequences = breachModel.GenerateBreachSequencesFromSurface(3, breachSurface, 3)
+	var breachSequence1 = breachSequences[0]
+	var breachSequence2 = breachSequences[1]
+	var breachSequence3 = breachSequences[2]
 
 	var hoverRowIndex = 0
 	var hoverColumnIndex = 0


### PR DESCRIPTION
This generates a solution based on the existing surface.

It traverses the surface to the full length of the available buffer in random steps, then shortens or overlaps the resulting sequences and shuffles them.

Might need a bit of fine tuning to not create too easy solutions,or e.g. only overlaps (and no shortening), depending on the preferred playstyle.

I would definitely squash this PR when merging, but for transparency I kept the commits in tact for now 😁 